### PR TITLE
[codestyle] Fixed first letter casing in class/method names

### DIFF
--- a/Tests/XCacheTest.php
+++ b/Tests/XCacheTest.php
@@ -9,14 +9,14 @@ namespace Joomla\Cache\Tests;
 use Joomla\Cache;
 
 /**
- * Tests for the Joomla\Cache\XCache class.
+ * Tests for the Joomla\Cache\Xcache class.
  *
  * @since  1.0
  */
-class XCacheTest extends \PHPUnit_Framework_TestCase
+class XcacheTest extends \PHPUnit_Framework_TestCase
 {
 	/**
-	 * @var    Cache\XCache
+	 * @var    Cache\Xcache
 	 * @since  1.0
 	 */
 	private $instance;
@@ -41,11 +41,11 @@ class XCacheTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the Joomla\Cache\XCache::clear method.
+	 * Tests the Joomla\Cache\Xcache::clear method.
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\Cache\XCache::clear
+	 * @covers  Joomla\Cache\Xcache::clear
 	 * @since   1.0
 	 */
 	public function testClear()
@@ -54,11 +54,11 @@ class XCacheTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the Joomla\Cache\XCache::exists method.
+	 * Tests the Joomla\Cache\Xcache::exists method.
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\Cache\XCache::exists
+	 * @covers  Joomla\Cache\Xcache::exists
 	 * @since   1.0
 	 */
 	public function testExists()
@@ -67,11 +67,11 @@ class XCacheTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the Joomla\Cache\XCache::get method.
+	 * Tests the Joomla\Cache\Xcache::get method.
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\Cache\XCache::get
+	 * @covers  Joomla\Cache\Xcache::get
 	 * @since   1.0
 	 */
 	public function testGet()
@@ -80,11 +80,11 @@ class XCacheTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the Joomla\Cache\XCache::remove method.
+	 * Tests the Joomla\Cache\Xcache::remove method.
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\Cache\XCache::remove
+	 * @covers  Joomla\Cache\Xcache::remove
 	 * @since   1.0
 	 */
 	public function testRemove()
@@ -93,11 +93,11 @@ class XCacheTest extends \PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * Tests the Joomla\Cache\XCache::set method.
+	 * Tests the Joomla\Cache\Xcache::set method.
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\Cache\XCache::set
+	 * @covers  Joomla\Cache\Xcache::set
 	 * @since   1.0
 	 */
 	public function testSet()
@@ -118,7 +118,7 @@ class XCacheTest extends \PHPUnit_Framework_TestCase
 
 		try
 		{
-			$this->instance = new Cache\XCache;
+			$this->instance = new Cache\Xcache;
 		}
 		catch (\Exception $e)
 		{

--- a/src/XCache.php
+++ b/src/XCache.php
@@ -15,7 +15,7 @@ use Psr\Cache\CacheItemInterface;
  *
  * @since  1.0
  */
-class XCache extends Cache
+class Xcache extends Cache
 {
 	/**
 	 * Constructor.


### PR DESCRIPTION
This PR fixes some more class/method/function names to comply with the CamelCase rules mentioned here:
http://joomla.github.io/coding-standards/?coding-standards/chapters/php.md
> ...be written in CamelCase even if using traditionally uppercase acronyms (such as XML, HTML).

Files should actually be renamed from XCache to Xcache too...