### PR TITLE
Implement PSR-16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "license": "GPL-2.0+",
     "require": {
         "php": "^5.5.9|~7.0",
-        "psr/cache": "~1.0"
+        "psr/cache": "~1.0",
+        "psr/simple-cache": "~1.0"
     },
     "require-dev": {
         "joomla/test": "~1.0",
@@ -23,7 +24,8 @@
         "ext-xcache": "To use XCache caching"
     },
     "provide": {
-        "psr/cache-implementation": "~1.0"
+        "psr/cache-implementation": "~1.0",
+        "psr/simple-cache-implementation": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Adapter/None.php
+++ b/src/Adapter/None.php
@@ -88,6 +88,21 @@ class None extends AbstractCacheItemPool
 	}
 
 	/**
+	 * Fetches a value from the cache.
+	 *
+	 * @param   string  $key      The unique key of this item in the cache.
+	 * @param   mixed   $default  Default value to return if the key does not exist.
+	 *
+	 * @return  mixed  The value of the item from the cache, or $default in case of cache miss.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function get($key, $default = null)
+	{
+		return $default;
+	}
+
+	/**
 	 * Test to see if the CacheItemPoolInterface is available
 	 *
 	 * @return  boolean  True on success, false otherwise

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -9,12 +9,13 @@
 namespace Joomla\Cache\Exception;
 
 use Psr\Cache\InvalidArgumentException as PsrInvalidArgumentExceptionInterface;
+use Psr\SimpleCache\InvalidArgumentException as PsrSimpleInvalidArgumentExceptionInterface;
 
 /**
  * Joomla! Caching Class Invalid Argument Exception
  *
  * @since  1.0
  */
-class InvalidArgumentException extends \InvalidArgumentException implements PsrInvalidArgumentExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements PsrInvalidArgumentExceptionInterface, PsrSimpleInvalidArgumentExceptionInterface
 {
 }

--- a/tests/Adapter/NoneTest.php
+++ b/tests/Adapter/NoneTest.php
@@ -43,6 +43,14 @@ class NoneTest extends CacheTestCase
 	}
 
 	/**
+	 * Tests the the Joomla\Cache\AbstractCacheItemPool::get method.
+	 */
+	public function testGet()
+	{
+		$this->assertNull($this->instance->get('foo'));
+	}
+
+	/**
 	 * Tests the Joomla\Cache\Cache::save method.
 	 */
 	public function testSave()
@@ -55,6 +63,28 @@ class NoneTest extends CacheTestCase
 	}
 
 	/**
+	 * Tests the Joomla\Cache\AbstractCacheItemPool::set method.
+	 */
+	public function testSet()
+	{
+		$this->assertTrue(
+			$this->instance->set('fooSet', 'barSet'),
+			'Set should return true for a valid item'
+		);
+	}
+
+	/**
+	 * Tests the Joomla\Cache\AbstractCacheItemPool::setMultiple method.
+	 */
+	public function testSetMultiple()
+	{
+		$this->assertTrue(
+			$this->instance->setMultiple(['key0' => 'value0', 'key1' => 'value1']),
+			'setMultiple() must return true if success'
+		);
+	}
+
+	/**
 	 * Tests the Joomla\Cache\Cache::getItems method.
 	 */
 	public function testGetItems()
@@ -62,6 +92,21 @@ class NoneTest extends CacheTestCase
 		$keys = ['foo', 'bar', 'hello'];
 
 		$this->assertContainsOnlyInstancesOf('Psr\Cache\CacheItemInterface', $this->instance->getItems($keys));
+	}
+
+	/**
+	 * Tests the Joomla\Cache\Cache::getMultiple method.
+	 */
+	public function testGetMultiple()
+	{
+		$keys = ['foo', 'bar', 'hello'];
+
+		$items = $this->instance->getMultiple($keys);
+
+		foreach ($items as $item)
+		{
+			$this->assertNull($item);
+		}
 	}
 
 	/**
@@ -83,11 +128,27 @@ class NoneTest extends CacheTestCase
 	}
 
 	/**
+	 * Tests the Joomla\Cache\Cache::delete method.
+	 */
+	public function testDelete()
+	{
+		$this->assertTrue($this->instance->delete('foo'));
+	}
+
+	/**
 	 * Tests the Joomla\Cache\Cache::hasItem method.
 	 */
 	public function testHasItem()
 	{
 		$this->assertFalse($this->instance->hasItem('foo'));
+	}
+
+	/**
+	 * Tests the Joomla\Cache\Cache::has method.
+	 */
+	public function testHas()
+	{
+		$this->assertFalse($this->instance->has('foo'));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

Implements support for PSR-16.  Similar to how the `php-cache` folks did it, the main interface is implemented directly into our base PSR-6 code and the PSR-16 methods just proxy into that.